### PR TITLE
Add integer validation and tests

### DIFF
--- a/src/v8n.js
+++ b/src/v8n.js
@@ -959,7 +959,25 @@ const rules = {
    */
   includes(expected) {
     return testIncludes(expected);
-  }
+  },
+
+  /**
+   * Rule function for integer validation.
+   *
+   * It's used to check if the validated value is an integer (not a decimal).
+   *
+   * @function
+   * @example
+   *
+   * v8n()
+   *  .integer()
+   *  .test(20); // true
+   *
+   * v8n()
+   *  .integer()
+   *  .test(2.2); // false
+   */
+  integer: () => value => Number.isInteger(value) || testIntegerPolyfill(value)
 };
 
 function testPattern(pattern) {
@@ -1020,6 +1038,12 @@ function makeTestDivisible(by, expected) {
 
 function testIncludes(expected) {
   return value => value.indexOf(expected) !== -1;
+}
+
+function testIntegerPolyfill(value) {
+  return (
+    typeof value === "number" && isFinite(value) && Math.floor(value) === value
+  );
 }
 
 export default v8n;

--- a/src/v8n.test.js
+++ b/src/v8n.test.js
@@ -463,6 +463,28 @@ describe("rules", () => {
     expect(not.test([1, 2, 3])).toBeTruthy();
     expect(not.test(2)).toBeTruthy();
   });
+
+  test("integer", () => {
+    const is = v8n().integer();
+    expect(is.test(0)).toBeTruthy();
+    expect(is.test(12)).toBeTruthy();
+    expect(is.test(99999999999)).toBeTruthy();
+    expect(is.test(-100000)).toBeTruthy();
+    expect(is.test("12")).toBeFalsy();
+    expect(is.test(3.14)).toBeFalsy();
+    expect(is.test(NaN)).toBeFalsy();
+    expect(is.test(Infinity)).toBeFalsy();
+
+    const not = v8n().not.integer();
+    expect(not.test(0)).toBeFalsy();
+    expect(not.test(12)).toBeFalsy();
+    expect(not.test(99999999999)).toBeFalsy();
+    expect(not.test(-100000)).toBeFalsy();
+    expect(not.test("12")).toBeTruthy();
+    expect(not.test(3.14)).toBeTruthy();
+    expect(not.test(NaN)).toBeTruthy();
+    expect(not.test(Infinity)).toBeTruthy();
+  });
 });
 
 describe("custom rules", () => {


### PR DESCRIPTION
This introduces an integer validation as per the talks in #26. It uses the JavaScript native way and falls back to a polyfill in case the user is using an unsupported browser.