### PR TITLE
Make ValidationException inherit from Error

### DIFF
--- a/src/v8n.js
+++ b/src/v8n.js
@@ -235,16 +235,36 @@ const core = {
  *
  * It contains information about the {@link Rule} which was been performed
  * during the fail, the value been validated and the cause of the thrown
- * exception.
+ * exception. It also contains a stacktrace if one is available.
  *
  * @param {Rule} rule performing when the exception was thrown
  * @param {any} value been validated when the exception was thrown
  * @param {any} cause cause of the thrown exception
  */
 function ValidationException(rule, value, cause) {
-  this.rule = rule;
-  this.value = value;
-  this.cause = cause;
+  var instance = new Error(cause);
+  instance.rule = rule;
+  instance.value = value;
+  Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(instance, ValidationException);
+  }
+  return instance;
+}
+
+ValidationException.prototype = Object.create(Error.prototype, {
+  constructor: {
+    value: Error,
+    enumerable: false,
+    writable: true,
+    configurable: true
+  }
+});
+
+if (Object.setPrototypeOf) {
+  Object.setPrototypeOf(ValidationException, Error);
+} else {
+  ValidationException.__proto__ = Error;
 }
 
 /**


### PR DESCRIPTION
Regarding issue #41 this makes ValidationException essentially an instance of Error including a stack trace as any regular error would have. This provides some consistency across JavaScript.

As of now I'm implementing this without ES6, though an ES6 approach would be nicer. This project already transpiles with Babel but seems to not use any new features like classes.

This introduces no changes in API whatsoever.