### PR TITLE
Fix bug with distribution files

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -75,8 +75,8 @@ const configs = [
     minified: true,
     sourceMap: true
   }),
-  buildConfig({ format: "esm", transpiled: false }),
-  buildConfig({ format: "system", transpiled: false })
+  buildConfig({ format: "esm" }),
+  buildConfig({ format: "system" })
 ];
 
 export default configs;


### PR DESCRIPTION
Transpile from es6 to es5 when building distribution files.

It fixes #44 