### PR TITLE
Add ability to return all errors from validation as array

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Dead simple fluent API. Customizable. Reusable.
 </p>
 
 <p align="center">
-<a href="#usage">Usage</a> - 
-<a href="#installation">Installation</a> - 
-<a href="#api">Documentation</a> 
+<a href="#usage">Usage</a> -
+<a href="#installation">Installation</a> -
+<a href="#api">Documentation</a>
 </p>
 
 ```javascript
@@ -51,14 +51,25 @@ We use the function [test](#test) to perform boolean based validations:
 ```javascript
 import v8n from "v8n";
 
-const isValid = v8n()
+v8n()
   .not.null()
   .string()
   .first("H")
   .last("o")
-  .test("Hello");
+  .test("Hello"); // true
+```
 
-isValid; // true
+### Array based validation
+
+We use the function [testAll](#testAll) to perform array based validations. The
+returned array will contain all failed rules or none if the validation passes:
+
+```javascript
+import v8n from "v8n";
+
+v8n()
+  .number()
+  .testAll("Hello"); // [Rule{ name: 'number', ... }]
 ```
 
 ### Exception based validation
@@ -330,7 +341,7 @@ v8n()
 Function used to produce a [Validation](#validation) object. The Validation object
 is used to configure a validation strategy and perform the validation tests.
 
-Returns **[Validation](#validation)** 
+Returns **[Validation](#validation)**
 
 #### extend
 
@@ -498,7 +509,7 @@ the issue happened, and about the value which was being validated.
 
 -   `rule` **[Rule](#rule)** the rule object which caused the validation
 -   `value` **any** the validated value
--   `remaining` **...any** 
+-   `remaining` **...any**
 
 ### modifiers
 

--- a/src/v8n.js
+++ b/src/v8n.js
@@ -200,6 +200,24 @@ const core = {
   },
 
   /**
+   * Performs array based validation.
+   *
+   * When this function is executed it performs the validation process and
+   * returns an array containing all failed rules. This will perform every
+   * validation regardless of failures.
+   *
+   * @param {any} value the value to be validated
+   * @returns {array} empty for successful validation
+   */
+  testAll(value) {
+    const err = [];
+    this.chain.forEach(rule => {
+      if (rule.fn(value) === rule.invert) err.push(rule);
+    });
+    return err;
+  },
+
+  /**
    * Performs exception based validation.
    *
    * When this function is executed it performs the validation process and

--- a/src/v8n.test.js
+++ b/src/v8n.test.js
@@ -36,6 +36,23 @@ describe("execution functions", () => {
     });
   });
 
+  describe("the 'testAll' function", () => {
+    const validation2 = v8n()
+      .number()
+      .between(5, 10)
+      .not.even();
+
+    it("should return an array of rules that failed", () => {
+      expect(Array.isArray(validation2.testAll("test"))).toBeTruthy();
+      expect(validation2.testAll("11")).toHaveLength(2);
+      expect(validation2.testAll(11)).toHaveLength(1);
+    });
+
+    it("should return an empty array if all rules passed", () => {
+      expect(validation2.testAll(7)).toHaveLength(0);
+    });
+  });
+
   describe("the 'check' function", () => {
     it("should throw exception for invalid value", () => {
       expect(() => validation.check("abcd")).toThrow();


### PR DESCRIPTION
Related to issue #24.

This will add the ability to receive information about every failed rule in the validation instead of failing fast once any error happens.

```javascript
v8n()
  .number()
  .between(5, 10)
  .testAll(true); // [Rule { name: 'number', ... }, Rule  { name: 'between', ... }]

v8n()
  .number()
  .between(5, 10)
  .testAll(7); // []
```

The implementation is fairly straightforward.