### PR TITLE
Refactor validation object to make it immutable

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -64,28 +64,30 @@ import ValidationException from "./ValidationException";
  * @module Validation
  */
 class Context {
-  constructor(chain = [], modifiers = []) {
+  constructor(chain = [], nextRuleModifiers = []) {
     this.chain = chain;
-    this.modifiers = modifiers;
+    this.nextRuleModifiers = nextRuleModifiers;
   }
 
   _applyRule(ruleFn, name) {
     return (...args) => {
       this.chain.push(
-        new Rule(name, ruleFn.apply(this, args), args, this.modifiers)
+        new Rule(name, ruleFn.apply(this, args), args, this.nextRuleModifiers)
       );
-      this.modifiers = [];
+      this.nextRuleModifiers = [];
       return this;
     };
   }
 
   _applyModifier(modifier, name) {
-    this.modifiers.push(new Modifier(name, modifier.simple, modifier.async));
+    this.nextRuleModifiers.push(
+      new Modifier(name, modifier.simple, modifier.async)
+    );
     return this;
   }
 
   _clone() {
-    return new Context(this.chain.slice(), this.modifiers.slice());
+    return new Context(this.chain.slice(), this.nextRuleModifiers.slice());
   }
 
   /**

--- a/src/Context.js
+++ b/src/Context.js
@@ -1,0 +1,188 @@
+import Rule from "./Rule";
+import Modifier from "./Modifier";
+import ValidationException from "./ValidationException";
+
+/**
+ * Represents an instance of a validation object. This is created by the entry
+ * point function {@link v8n}.
+ *
+ * **rules:**
+ *
+ * A validation strategy is defined by calling `rules` functions on the
+ * validation object. Each call to a `rule` function will add that rule to the
+ * validation strategy chain and return the validation object instance for
+ * chaining `rules` functions calls together.
+ *
+ * All the rules functions that are available for use by a {@link Validation}
+ * object instance are actually declared  in the {@link rules} object. Those
+ * `rules` functions are injected into each Validation object instance.
+ *
+ * Look at the {@link rules} object to see all the available `rules`.
+ *
+ * **The `not` modifier**
+ *
+ * To invert a `rule` meaning, the modifier {@link modifiers.not not} must be
+ * invoked before the `rule` function call. It will invert the next `rule`
+ * call meaning.
+ *
+ * **Validating**
+ *
+ * There are two way to perform a validation: synchronous and asynchronous.
+ *
+ * When you have a validation strategy with promise-based rules, like a rule
+ * that performs an API check or any other kind of asynchronous test, you
+ * should use the {@link core.testAsync testAsync} function. This function
+ * produces a promise based validation.
+ *
+ * But, if your validation strategy contains **only** synchronous rules, like
+ * `.string()`, `.minLength(2)`, whatever, you'd better use the functions
+ * {@link core.test test} or {@link core.check check}.
+ *
+ * > Look at these functions documentation to know more about them.
+ *
+ * @example
+ * // Synchronous validation
+ *
+ * v8n() // Creates a validation object instance
+ *  .not.null()   // Inverting the `null` rule call to `not null`
+ *  .minLength(3) // Chaining `rules` to the validation strategy
+ *  .test("some value");  // Executes the validation test function
+ *
+ * @example
+ * // Asynchronous validation
+ *
+ * v8n()
+ *   .not.null()
+ *   .someAsyncRule() // some asynchronous rule
+ *   .testAsync("some value")
+ *   .then(value => {
+ *     // valid
+ *   }).catch(ex => {
+ *     // invalid!
+ *   });
+ *
+ * @module Validation
+ */
+class Context {
+  constructor(chain = [], modifiers = []) {
+    this.chain = chain;
+    this.modifiers = modifiers;
+  }
+
+  _applyRule(ruleFn, name) {
+    return (...args) => {
+      this.chain.push(
+        new Rule(name, ruleFn.apply(this, args), args, this.modifiers)
+      );
+      this.modifiers = [];
+      return this;
+    };
+  }
+
+  _applyModifier(modifier, name) {
+    this.modifiers.push(new Modifier(name, modifier.simple, modifier.async));
+    return this;
+  }
+
+  _clone() {
+    return new Context(this.chain.slice(), this.modifiers.slice());
+  }
+
+  /**
+   * Performs boolean based validation.
+   *
+   * When this function is executed it performs the validation process and
+   * returns a `boolean` result.
+   *
+   * @param {any} value the value to be validated
+   * @returns {boolean} true for valid and false for invalid
+   */
+  test(value) {
+    return this.chain.every(rule => rule._test(value));
+  }
+
+  /**
+   * Performs array based validation.
+   *
+   * When this function is executed it performs the validation process and
+   * returns an array containing all failed rules. This will perform every
+   * validation regardless of failures.
+   *
+   * @param {any} value the value to be validated
+   * @returns {array} empty for successful validation
+   */
+  testAll(value) {
+    const err = [];
+    this.chain.forEach(rule => {
+      if (!rule._test(value)) err.push(rule);
+    });
+    return err;
+  }
+
+  /**
+   * Performs exception based validation.
+   *
+   * When this function is executed it performs the validation process and
+   * throws a {@link ValidationException} when the value is not valid.
+   *
+   * > The exception thrown by this validation function contains a reference to
+   * > the performed {@link Rule}.
+   *
+   * @throws {ValidationException} exception thrown when the validation fails
+   * @param {any} value the value to be validated
+   */
+  check(value) {
+    this.chain.forEach(rule => {
+      try {
+        if (!rule._check(value)) {
+          throw new ValidationException(rule, value, null);
+        }
+      } catch (cause) {
+        throw new ValidationException(rule, value, cause);
+      }
+    });
+  }
+
+  /**
+   * Performs asynchronous validation.
+   *
+   * When this function is used it performs the validation process
+   * asynchronously, and it returns a promise that resolves to the validated
+   * value when it's valid and rejects with a {@link ValidationException} when
+   * it's invalid or when an exception occurs.
+   *
+   * > To learn more about asynchronous validation, look at the
+   * > {@link Validation} documentation section.
+   *
+   * > For a validation strategy with non promise-based rules, you'd better use
+   * > the {@link core.test test} and {@link core.check check} functions.
+   *
+   * @see ValidationException
+   * @param {any} value the value to be validated
+   * @returns {Promise} promise that resolves to the validated value or rejects
+   * with a {@link ValidationException}
+   */
+  testAsync(value) {
+    return new Promise((resolve, reject) => {
+      executeAsyncRules(value, this.chain.slice(), resolve, reject);
+    });
+  }
+}
+
+function executeAsyncRules(value, rules, resolve, reject) {
+  if (rules.length) {
+    const rule = rules.shift();
+    rule._testAsync(value).then(
+      () => {
+        executeAsyncRules(value, rules, resolve, reject);
+      },
+      cause => {
+        reject(new ValidationException(rule, value, cause));
+      }
+    );
+  } else {
+    resolve(value);
+  }
+}
+
+export default Context;

--- a/src/Modifier.js
+++ b/src/Modifier.js
@@ -1,6 +1,7 @@
 //  TODO: add docs
 class Modifier {
-  constructor(perform, performAsync) {
+  constructor(name, perform, performAsync) {
+    this.name = name;
     this.perform = perform;
     this.performAsync = performAsync;
   }

--- a/src/v8n.js
+++ b/src/v8n.js
@@ -1,6 +1,4 @@
-import Rule from "./Rule";
-import Modifier from "./Modifier";
-import ValidationException from "./ValidationException";
+import Context from "./Context";
 
 /**
  * Function used to produce a {@link Validation} object. The Validation object
@@ -10,73 +8,7 @@ import ValidationException from "./ValidationException";
  * @returns {Validation}
  */
 function v8n() {
-  /**
-   * Represents an instance of a validation object. This is created by the entry
-   * point function {@link v8n}.
-   *
-   * **rules:**
-   *
-   * A validation strategy is defined by calling `rules` functions on the
-   * validation object. Each call to a `rule` function will add that rule to the
-   * validation strategy chain and return the validation object instance for
-   * chaining `rules` functions calls together.
-   *
-   * All the rules functions that are available for use by a {@link Validation}
-   * object instance are actually declared  in the {@link rules} object. Those
-   * `rules` functions are injected into each Validation object instance.
-   *
-   * Look at the {@link rules} object to see all the available `rules`.
-   *
-   * **The `not` modifier**
-   *
-   * To invert a `rule` meaning, the modifier {@link modifiers.not not} must be
-   * invoked before the `rule` function call. It will invert the next `rule`
-   * call meaning.
-   *
-   * **Validating**
-   *
-   * There are two way to perform a validation: synchronous and asynchronous.
-   *
-   * When you have a validation strategy with promise-based rules, like a rule
-   * that performs an API check or any other kind of asynchronous test, you
-   * should use the {@link core.testAsync testAsync} function. This function
-   * produces a promise based validation.
-   *
-   * But, if your validation strategy contains **only** synchronous rules, like
-   * `.string()`, `.minLength(2)`, whatever, you'd better use the functions
-   * {@link core.test test} or {@link core.check check}.
-   *
-   * > Look at these functions documentation to know more about them.
-   *
-   * @example
-   * // Synchronous validation
-   *
-   * v8n() // Creates a validation object instance
-   *  .not.null()   // Inverting the `null` rule call to `not null`
-   *  .minLength(3) // Chaining `rules` to the validation strategy
-   *  .test("some value");  // Executes the validation test function
-   *
-   * @example
-   * // Asynchronous validation
-   *
-   * v8n()
-   *   .not.null()
-   *   .someAsyncRule() // some asynchronous rule
-   *   .testAsync("some value")
-   *   .then(value => {
-   *     // valid
-   *   }).catch(ex => {
-   *     // invalid!
-   *   });
-   *
-   * @module Validation
-   */
-  const context = {
-    chain: [],
-    modifiers: []
-  };
-
-  return new Proxy(context, contextProxyHandler);
+  return createValidation(new Context());
 }
 
 // Custom rules
@@ -154,142 +86,26 @@ v8n.clearCustomRules = function() {
   customRules = {};
 };
 
-const contextProxyHandler = {
-  get: function(obj, prop, receiver) {
+const newContextProxyHandler = {
+  get(obj, prop) {
     if (prop in obj) {
       return obj[prop];
     }
+    const validation = createValidation(obj._clone());
     if (prop in availableModifiers) {
-      receiver.modifiers.push(availableModifiers[prop]);
-      return receiver;
+      return validation._applyModifier(availableModifiers[prop], prop);
     }
     if (prop in customRules) {
-      return applyRule.call(receiver, customRules[prop], prop);
+      return validation._applyRule(customRules[prop], prop);
     }
     if (prop in availableRules) {
-      return applyRule.call(receiver, availableRules[prop], prop);
-    }
-    if (prop in core) {
-      return core[prop];
+      return validation._applyRule(availableRules[prop], prop);
     }
   }
 };
 
-function applyRule(rule, name) {
-  return (...args) => {
-    this.chain.push(
-      new Rule(name, rule.apply(this, args), args, this.modifiers)
-    );
-    this.modifiers = [];
-    return this;
-  };
-}
-
-/**
- * Group of functionalities that can be performed on a validation object.
- *
- * > This object should not be used directly. All of its functionalities will be
- * injected into the {@link Validation} object instance when a validation is
- * performed.
- *
- * > To know more about the validation process, look at {@link Validation} docs.
- */
-const core = {
-  /**
-   * Performs boolean based validation.
-   *
-   * When this function is executed it performs the validation process and
-   * returns a `boolean` result.
-   *
-   * @param {any} value the value to be validated
-   * @returns {boolean} true for valid and false for invalid
-   */
-  test(value) {
-    return this.chain.every(rule => rule._test(value));
-  },
-
-  /**
-   * Performs array based validation.
-   *
-   * When this function is executed it performs the validation process and
-   * returns an array containing all failed rules. This will perform every
-   * validation regardless of failures.
-   *
-   * @param {any} value the value to be validated
-   * @returns {array} empty for successful validation
-   */
-  testAll(value) {
-    const err = [];
-    this.chain.forEach(rule => {
-      if (!rule._test(value)) err.push(rule);
-    });
-    return err;
-  },
-
-  /**
-   * Performs exception based validation.
-   *
-   * When this function is executed it performs the validation process and
-   * throws a {@link ValidationException} when the value is not valid.
-   *
-   * > The exception thrown by this validation function contains a reference to
-   * > the performed {@link Rule}.
-   *
-   * @throws {ValidationException} exception thrown when the validation fails
-   * @param {any} value the value to be validated
-   */
-  check(value) {
-    this.chain.forEach(rule => {
-      try {
-        if (!rule._check(value)) {
-          throw new ValidationException(rule, value, null);
-        }
-      } catch (cause) {
-        throw new ValidationException(rule, value, cause);
-      }
-    });
-  },
-
-  /**
-   * Performs asynchronous validation.
-   *
-   * When this function is used it performs the validation process
-   * asynchronously, and it returns a promise that resolves to the validated
-   * value when it's valid and rejects with a {@link ValidationException} when
-   * it's invalid or when an exception occurs.
-   *
-   * > To learn more about asynchronous validation, look at the
-   * > {@link Validation} documentation section.
-   *
-   * > For a validation strategy with non promise-based rules, you'd better use
-   * > the {@link core.test test} and {@link core.check check} functions.
-   *
-   * @see ValidationException
-   * @param {any} value the value to be validated
-   * @returns {Promise} promise that resolves to the validated value or rejects
-   * with a {@link ValidationException}
-   */
-  testAsync(value) {
-    return new Promise((resolve, reject) => {
-      executeAsyncRules(value, this.chain.slice(), resolve, reject);
-    });
-  }
-};
-
-function executeAsyncRules(value, rules, resolve, reject) {
-  if (rules.length) {
-    const rule = rules.shift();
-    rule._testAsync(value).then(
-      () => {
-        executeAsyncRules(value, rules, resolve, reject);
-      },
-      cause => {
-        reject(new ValidationException(rule, value, cause));
-      }
-    );
-  } else {
-    resolve(value);
-  }
+function createValidation(context) {
+  return new Proxy(context, newContextProxyHandler);
 }
 
 /**
@@ -319,22 +135,22 @@ const availableModifiers = {
    * v8n()
    *  .not.equal("three");
    */
-  not: new Modifier(
-    fn => value => !fn(value),
-    fn => value => Promise.resolve(fn(value)).then(result => !result)
-  ),
+  not: {
+    simple: fn => value => !fn(value),
+    async: fn => value => Promise.resolve(fn(value)).then(result => !result)
+  },
 
-  some: new Modifier(
-    fn => value => split(value).some(fn),
-    fn => value =>
+  some: {
+    simple: fn => value => split(value).some(fn),
+    async: fn => value =>
       Promise.all(split(value).map(fn)).then(result => result.some(Boolean))
-  ),
+  },
 
-  every: new Modifier(
-    fn => value => split(value).every(fn),
-    fn => value =>
+  every: {
+    simple: fn => value => split(value).every(fn),
+    async: fn => value =>
       Promise.all(split(value).map(fn)).then(result => result.every(Boolean))
-  )
+  }
 };
 
 function split(value) {

--- a/src/v8n.test.js
+++ b/src/v8n.test.js
@@ -5,25 +5,37 @@ beforeEach(() => {
   v8n.clearCustomRules();
 });
 
-describe("rules chain", () => {
+describe("chaining", () => {
   // TODO: make sure 'modifiers' are included in debug
   const validation = v8n()
     .string()
-    .lowercase()
-    .null()
+    .not.every.lowercase()
+    .not.null()
     .first("a")
     .last("e")
+    .some.equal("l")
     .length(3, 5);
 
   it("should chain rules", () => {
     expect(debugRules(validation)).toEqual([
       "string()",
-      "lowercase()",
-      "null()",
+      "not.every.lowercase()",
+      "not.null()",
       'first("a")',
       'last("e")',
+      'some.equal("l")',
       "length(3, 5)"
     ]);
+  });
+});
+
+describe("the 'validation' object", () => {
+  it("should be immutable", () => {
+    const a = v8n().number();
+    const b = a.not.equal(10);
+    expect(a).not.toBe(b);
+    expect(a.test(10)).toBeTruthy();
+    expect(b.test(10)).toBeFalsy();
   });
 });
 
@@ -1041,8 +1053,10 @@ function debugRules(validation) {
   return validation.chain.map(ruleId);
 }
 
-function ruleId({ name, args }) {
-  return `${name}(${args.map(parseArg).join(", ")})`;
+function ruleId({ name, modifiers, args }) {
+  const modifiersStr = modifiers.map(it => it.name).join(".");
+  const argsStr = args.map(parseArg).join(", ");
+  return `${modifiersStr ? modifiersStr + "." : ""}${name}(${argsStr})`;
 }
 
 function parseArg(arg) {


### PR DESCRIPTION
The immutable approach is a good thing for code clarity, functional style and a lot of other improvements. But the most important benefit of  this change it to make validation objects able to be `forked` into another validation objects, like this:

```javascript
const a = v8n().number();
const b = a.min(40);
```

This kind of behavior was not possible in the previous mutable implementation as the `b.min(40)` call was also changing the `a` strategy.

In the new immutable approach, now `a` and `b` are different in their behaviors:

```javascript
a.test(40); // true
b.test(40); // false
```