### PR TITLE
Add "any" rule for branching validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Rule `passesAnyOf()` to perform branching validation.
+
 ## [1.1.2] - 2018-07-26
 
 ### Fixed

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1005,7 +1005,7 @@ sidebar: auto
   This rule checks if any of the validations given as its argument passes when
   performed against the validated value. If some of them pass, the rule passes.
   But if all of them fail, the rule fails, too. If no validation is given as the
-  argument, the rule also passes.
+  argument, the rule fails.
 
   ```js
   const validation = v8n().any(

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -992,7 +992,7 @@ sidebar: auto
   }); // false
   ```
 
-### any
+### passesAnyOf
 
 - **Signature:** `any(...validations)`
 
@@ -1008,7 +1008,7 @@ sidebar: auto
   argument, the rule fails.
 
   ```js
-  const validation = v8n().any(
+  const validation = v8n().passesAnyOf(
     v8n().number(),
     v8n().null()
   );

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -992,6 +992,32 @@ sidebar: auto
   }); // false
   ```
 
+### any
+
+- **Signature:** `any(...validations)`
+
+- **Arguments:**
+
+  - `validations: ...Validation`
+
+- **Usage:**
+
+  This rule checks if any of the validations given as its argument passes when
+  performed against the validated value. If some of them pass, the rule passes.
+  But if all of them fail, the rule fails, too. If no validation is given as the
+  argument, the rule also passes.
+
+  ```js
+  const validation = v8n().any(
+    v8n().number(),
+    v8n().null()
+  );
+
+  validation.test(12); // true
+  validation.test(null); // true
+  validation.test("Hello"); // false
+  ```
+
 ## Built-in modifiers
 
 ### not

--- a/src/v8n.js
+++ b/src/v8n.js
@@ -153,7 +153,7 @@ const availableRules = {
   // branching
 
   passesAnyOf: (...validations) => value =>
-    validations.some(it => it.test(value))
+    validations.some(validation => validation.test(value))
 };
 
 function testPattern(pattern) {

--- a/src/v8n.js
+++ b/src/v8n.js
@@ -152,7 +152,8 @@ const availableRules = {
 
   // branching
 
-  any: (...validations) => value => validations.some(it => it.test(value))
+  passesAnyOf: (...validations) => value =>
+    validations.some(it => it.test(value))
 };
 
 function testPattern(pattern) {

--- a/src/v8n.js
+++ b/src/v8n.js
@@ -152,8 +152,7 @@ const availableRules = {
 
   // branching
 
-  any: (...validations) => value =>
-    !validations.length || validations.some(it => it.test(value))
+  any: (...validations) => value => validations.some(it => it.test(value))
 };
 
 function testPattern(pattern) {

--- a/src/v8n.js
+++ b/src/v8n.js
@@ -148,7 +148,12 @@ const availableRules = {
 
   integer: () => value => Number.isInteger(value) || testIntegerPolyfill(value),
 
-  schema: schema => testSchema(schema)
+  schema: schema => testSchema(schema),
+
+  // branching
+
+  any: (...validations) => value =>
+    !validations.length || validations.some(it => it.test(value))
 };
 
 function testPattern(pattern) {

--- a/src/v8n.test.js
+++ b/src/v8n.test.js
@@ -793,9 +793,9 @@ describe("rules", () => {
     });
   });
 
-  describe("any", () => {
+  describe("passesAnyOf", () => {
     it("should pass if any of the received validation is valid", () => {
-      const is = v8n().any(
+      const is = v8n().passesAnyOf(
         v8n().number(),
         v8n().schema({
           id: v8n().string()
@@ -810,7 +810,7 @@ describe("rules", () => {
       expect(is.test(11)).toBeTruthy();
       expect(is.test({ id: "ef13c" })).toBeTruthy();
 
-      const not = v8n().not.any(
+      const not = v8n().not.passesAnyOf(
         v8n().number(),
         v8n().schema({
           id: v8n().string()
@@ -829,7 +829,7 @@ describe("rules", () => {
     it("should fail if there's no validation specified", () => {
       expect(
         v8n()
-          .any()
+          .passesAnyOf()
           .test("Foo")
       ).toBeFalsy();
     });
@@ -837,7 +837,7 @@ describe("rules", () => {
     it("should work together with other rules", () => {
       const validation = v8n()
         .string()
-        .any(v8n().every.lowercase(), v8n().every.uppercase());
+        .passesAnyOf(v8n().every.lowercase(), v8n().every.uppercase());
 
       expect(validation.test("HELLO")).toBeTruthy();
       expect(validation.test("hello")).toBeTruthy();
@@ -846,9 +846,9 @@ describe("rules", () => {
     });
 
     test("composition", () => {
-      const validation = v8n().any(
-        v8n().any(v8n().null(), v8n().undefined()),
-        v8n().any(v8n().number(), v8n().boolean())
+      const validation = v8n().passesAnyOf(
+        v8n().passesAnyOf(v8n().null(), v8n().undefined()),
+        v8n().passesAnyOf(v8n().number(), v8n().boolean())
       );
 
       expect(validation.test(null)).toBeTruthy();

--- a/src/v8n.test.js
+++ b/src/v8n.test.js
@@ -794,7 +794,7 @@ describe("rules", () => {
   });
 
   describe("any", () => {
-    it("should be valid if any received validation is valid", () => {
+    it("should pass if any of the received validation is valid", () => {
       const is = v8n().any(
         v8n().number(),
         v8n().schema({
@@ -826,12 +826,12 @@ describe("rules", () => {
       expect(not.test({ id: "ef13c" })).toBeFalsy();
     });
 
-    it("should be valid if there's no validation specified", () => {
+    it("should fail if there's no validation specified", () => {
       expect(
         v8n()
           .any()
           .test("Foo")
-      ).toBeTruthy();
+      ).toBeFalsy();
     });
 
     it("should work together with other rules", () => {

--- a/src/v8n.test.js
+++ b/src/v8n.test.js
@@ -792,6 +792,72 @@ describe("rules", () => {
       expect(() => not.check(validObj)).toThrow();
     });
   });
+
+  describe("any", () => {
+    it("should be valid if any received validation is valid", () => {
+      const is = v8n().any(
+        v8n().number(),
+        v8n().schema({
+          id: v8n().string()
+        })
+      );
+
+      expect(is.test(true)).toBeFalsy();
+      expect(is.test(undefined)).toBeFalsy();
+      expect(is.test("Hello")).toBeFalsy();
+      expect(is.test(null)).toBeFalsy();
+      expect(is.test({})).toBeFalsy();
+      expect(is.test(11)).toBeTruthy();
+      expect(is.test({ id: "ef13c" })).toBeTruthy();
+
+      const not = v8n().not.any(
+        v8n().number(),
+        v8n().schema({
+          id: v8n().string()
+        })
+      );
+
+      expect(not.test(true)).toBeTruthy();
+      expect(not.test(undefined)).toBeTruthy();
+      expect(not.test("Hello")).toBeTruthy();
+      expect(not.test(null)).toBeTruthy();
+      expect(not.test({})).toBeTruthy();
+      expect(not.test(11)).toBeFalsy();
+      expect(not.test({ id: "ef13c" })).toBeFalsy();
+    });
+
+    it("should be valid if there's no validation specified", () => {
+      expect(
+        v8n()
+          .any()
+          .test("Foo")
+      ).toBeTruthy();
+    });
+
+    it("should work together with other rules", () => {
+      const validation = v8n()
+        .string()
+        .any(v8n().every.lowercase(), v8n().every.uppercase());
+
+      expect(validation.test("HELLO")).toBeTruthy();
+      expect(validation.test("hello")).toBeTruthy();
+      expect(validation.test("Hello")).toBeFalsy();
+      expect(validation.test({})).toBeFalsy();
+    });
+
+    test("composition", () => {
+      const validation = v8n().any(
+        v8n().any(v8n().null(), v8n().undefined()),
+        v8n().any(v8n().number(), v8n().boolean())
+      );
+
+      expect(validation.test(null)).toBeTruthy();
+      expect(validation.test(undefined)).toBeTruthy();
+      expect(validation.test(12)).toBeTruthy();
+      expect(validation.test(false)).toBeTruthy();
+      expect(validation.test("Hello")).toBeFalsy();
+    });
+  });
 });
 
 describe("validation composition", () => {


### PR DESCRIPTION
This is a preliminary implementation and should be validated yet.

We have to make some decisions like what we should expect when no validation is given. Should we get a valid or invalid result?

In the current implementation, I decided to make the arguments spread to an array `(... validations)` instead of getting an array directly. What do you think about?

And this PR closes #53.