### PR TITLE
Fix API specification for "some" and "every" modifiers

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1015,7 +1015,7 @@ sidebar: auto
 
 ### some
 
-- **Applicable Types:** `array`
+- **Applicable Types:** `array|string`
 
 - **Usage:**
 
@@ -1034,7 +1034,7 @@ sidebar: auto
 
 ### every
 
-- **Applicable Types:** `array`
+- **Applicable Types:** `array|string`
 
 - **Usage:**
 


### PR DESCRIPTION
* Add "string" type as a applicable type along with the already used
"array" type.