### PR TITLE
Rename ValidationException to ValidationError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Rename `ValidationException` to `ValidationError`
+
 ## [1.2.0] - 2018-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 The ultimate JavaScript validation library you've ever needed.<br/>
 Dead simple fluent API. Customizable. Reusable.
 </p>
-
 <p align="center">
   <a href="https://circleci.com/gh/imbrn/v8n/tree/master">
     <img src="https://circleci.com/gh/imbrn/v8n/tree/master.svg?style=svg" alt="CircleCI" />
@@ -188,8 +187,8 @@ const failed = v8n()
 
 failed;
 // [
-//   ValidationException { rule: { name: "string", ... } },
-//   ValidationException { rule: { name: "minLength", ... } }
+//   ValidationError { rule: { name: "string", ... } },
+//   ValidationError { rule: { name: "minLength", ... } }
 // ]
 ```
 

--- a/docs/Validation.md
+++ b/docs/Validation.md
@@ -167,9 +167,9 @@ If you really need to know what was wrong with the value you passed to v8n,
 simply getting `true` or `false` won't do you any good. This is where
 array-based comes in. If you use `testAll()` you will always receive an array in
 return. The array will be empty if no rules failed, but it will contain
-ValidationException objects indicating each fail if they occur. This also means
-that this strategy does not stop when any rule fails like the boolean-based
-version does, instead it will always run all the rules.
+ValidationError objects indicating each fail if they occur. This also means that
+this strategy does not stop when any rule fails like the boolean-based version
+does, instead it will always run all the rules.
 
 ```js
 v8n()
@@ -182,7 +182,7 @@ v8n()
   .string()
   .first("H")
   .last("o")
-  .testAll("Hi"); // Returns [ValidationException{rule: {name: "last"...}, ...}]
+  .testAll("Hi"); // Returns [ValidationError{rule: {name: "last"...}, ...}]
 ```
 
 This is useful for providing detailed error messages but can also be used for
@@ -190,7 +190,7 @@ any number of other purposes. For some more in-depth examples head over
 [to the documentation for `testAll()`](/api/#testall).
 
 ::: tip
-The array will contain [`ValidationException` objects](/api/#validationexception)
+The array will contain [`ValidationError` objects](/api/#validationexception)
 that you can work with.
 :::
 
@@ -222,10 +222,10 @@ try {
 }
 ```
 
-The resulting [`ValidationException`](/api/#validationexception) will also contain
+The resulting [`ValidationError`](/api/#validationexception) will also contain
 information about the rule that failed so that you may display errors or
-similar. You can find out more in the
-[documentation for `check()`](/api/#check).
+similar. You can find out more in the [documentation for
+`check()`](/api/#check).
 
 ### Asynchronous validation
 
@@ -238,7 +238,7 @@ type of rule though, since they will return a result before the server has a
 chance to respond. This is where we need `testAsync()` to run validations
 asynchronously and await all the returns. You will ultimately receive a
 `Promise` back which you can react to. It resolves to the value your validated
-and would reject to a `ValidationException`.
+and would reject to a `ValidationError`.
 
 ```js
 v8n()

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -68,12 +68,12 @@ sidebar: auto
 
 - **Details:**
 
-  This class represents a rule. It is returned from
-  [array-based validation](#testall) and is contained in the rule property of a
-  [`ValidationException`](#validationexception). The `fn` property contains the
-  actual function the validation strategy uses to validate the value.
+  This class represents a rule. It is returned from [array-based
+  validation](#testall) and is contained in the rule property of a
+  [`ValidationError`](#validationerror). The `fn` property contains the actual
+  function the validation strategy uses to validate the value.
 
-- **See also:** [Modifier](#modifier), [ValidationException](#validationexception)
+- **See also:** [Modifier](#modifier), [ValidationError](#validationerror)
 
 ### Modifier
 
@@ -91,7 +91,7 @@ sidebar: auto
 
 - **See also:** [Rule](#rule)
 
-### ValidationException
+### ValidationError
 
 - **Extends:** [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)
 
@@ -153,13 +153,13 @@ sidebar: auto
 
   - `value: any`
 
-- **Returns:** [`ValidationException[]`](#validationexception)
+- **Returns:** [`ValidationError[]`](#validationerror)
 
 - **Usage:**
 
   This function is used for array-based validation. It is chained at the end of
-  all the rules and will return an array containing ValidationException objects,
-  one for each failed rule. The array is empty if the validation succeeded.
+  all the rules and will return an array containing ValidationError objects, one
+  for each failed rule. The array is empty if the validation succeeded.
 
   ```js
   v8n()
@@ -171,10 +171,10 @@ sidebar: auto
     .number()
     .min(4)
     .test(3);
-  // [ ValidationException{ rule: { name: "min"...}, value: 3 ...} ... ]
+  // [ ValidationError{ rule: { name: "min"...}, value: 3 ...} ... ]
   ```
 
-- **See also:** [ValidationException](#validationexception)
+- **See also:** [ValidationError](#validationerror)
 
 ### check
 
@@ -184,14 +184,14 @@ sidebar: auto
 
   - `value: any`
 
-- **Throws:** [`ValidationException`](#validationexception)
+- **Throws:** [`ValidationError`](#validationerror)
 
 - **Usage:**
 
   This function is used for exception-based validation. It is chained at the end
   of all the rules and will return nothing if the validation passed. If any rule
-  fails a [`ValidationException`](#validationexception) is thrown that contains
-  the failed rule.
+  fails a [`ValidationError`](#validationerror) is thrown that contains the
+  failed rule.
 
   ```js
   v8n()
@@ -200,10 +200,10 @@ sidebar: auto
 
   v8n()
     .string()
-    .test(3); // ValidationException is thrown
+    .test(3); // ValidationError is thrown
   ```
 
-- **See also:** [ValidationException](#validationexception)
+- **See also:** [ValidationError](#validationerror)
 
 ### testAsync
 
@@ -217,12 +217,12 @@ sidebar: auto
 
 - **Usage:**
 
-  This function is used for asynchronous validation. It is chained at the end
-  of all the rules and will return a `Promise` that will resolve to the
-  validated value if validation passes or reject to a
-  [`ValidationException`](#validationexception) if it fails. This strategy must
-  be used if any asynchronous rules are used. It allows for the use of regular
-  rules next to asynchronous ones.
+  This function is used for asynchronous validation. It is chained at the end of
+  all the rules and will return a `Promise` that will resolve to the validated
+  value if validation passes or reject to a
+  [`ValidationError`](#validationerror) if it fails. This strategy must be used
+  if any asynchronous rules are used. It allows for the use of regular rules
+  next to asynchronous ones.
 
   ::: danger
   All other validation strategies won't work for asynchronous rules.
@@ -250,7 +250,7 @@ sidebar: auto
     .testAsync("Test"); // Promise
   ```
 
-- **See also:** [ValidationException](#validationexception)
+- **See also:** [ValidationError](#validationerror)
 
 ## Built-in rules
 

--- a/src/Context.js
+++ b/src/Context.js
@@ -1,6 +1,6 @@
 import Rule from "./Rule";
 import Modifier from "./Modifier";
-import ValidationException from "./ValidationException";
+import ValidationError from "./ValidationError";
 
 class Context {
   constructor(chain = [], nextRuleModifiers = []) {
@@ -39,7 +39,7 @@ class Context {
       try {
         rule._check(value);
       } catch (ex) {
-        err.push(new ValidationException(rule, value, ex));
+        err.push(new ValidationError(rule, value, ex));
       }
     });
     return err;
@@ -50,7 +50,7 @@ class Context {
       try {
         rule._check(value);
       } catch (ex) {
-        throw new ValidationException(rule, value, ex);
+        throw new ValidationError(rule, value, ex);
       }
     });
   }
@@ -70,7 +70,7 @@ function executeAsyncRules(value, rules, resolve, reject) {
         executeAsyncRules(value, rules, resolve, reject);
       },
       cause => {
-        reject(new ValidationException(rule, value, cause));
+        reject(new ValidationError(rule, value, cause));
       }
     );
   } else {

--- a/src/ValidationError.js
+++ b/src/ValidationError.js
@@ -1,8 +1,8 @@
-class ValidationException extends Error {
+class ValidationError extends Error {
   constructor(rule, value, cause, target, ...remaining) {
     super(remaining);
     if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, ValidationException);
+      Error.captureStackTrace(this, ValidationError);
     }
     this.rule = rule;
     this.value = value;
@@ -11,4 +11,4 @@ class ValidationException extends Error {
   }
 }
 
-export default ValidationException;
+export default ValidationError;


### PR DESCRIPTION
## Description

This change was made due proposed by #104.

This change does not require a major version update as the `ValidationException` object was not exposed as a public API in the current version 1. But as the documentation exposes the naming `ValidationException`, this maybe should be in a patch update.

## Type of change

- This is an internal naming change, but it affects documentation.

## Checklist:

- [X] I have created my branch from a recent version of `master`
- [X] The code is clean and easy to understand
- [X] I have made corresponding changes to the documentation
- [X] I have added changes to the `Unreleased` section of the CHANGELOG
