### PR TITLE
Fix bug with `integer` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Bug with polyfill for `integer` rule
+
 ## [1.2.1] - 2018-08-17
 
 ### Changed

--- a/src/v8n.js
+++ b/src/v8n.js
@@ -147,7 +147,7 @@ const availableRules = {
     return testIncludes(expected);
   },
 
-  integer: () => value => Number.isInteger(value) || testIntegerPolyfill(value),
+  integer: () => testInteger(),
 
   schema: schema => testSchema(schema),
 
@@ -221,7 +221,12 @@ function testIncludes(expected) {
   return value => value.indexOf(expected) !== -1;
 }
 
-function testIntegerPolyfill(value) {
+function testInteger() {
+  const isInteger = Number.isInteger || isIntegerPolyfill;
+  return value => isInteger(value);
+}
+
+function isIntegerPolyfill(value) {
   return (
     typeof value === "number" && isFinite(value) && Math.floor(value) === value
   );


### PR DESCRIPTION
## Description

Make the `integer` rule logic to fallback to an integer test polyfill when `Number.isInteger` is not available.

<!-- A summary of the change made and how it is supposed to fix the related issue. Include relevant motivation and context. -->

Fixes #117 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have created my branch from a recent version of `stable`
- [X] The code is clean and easy to understand
- [X] I have added changes to the `Unreleased` section of the CHANGELOG
