### PR TITLE
Fix bug with `Infinity` values in range based rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Bug with `Infinity` values in range-based rules
+
 ## [1.2.1] - 2018-08-17
 
 ### Changed

--- a/src/v8n.js
+++ b/src/v8n.js
@@ -129,13 +129,13 @@ const availableRules = {
 
   range: makeTestRange(undefined, undefined, true, true),
 
-  lessThan: makeTestRange(-Infinity),
+  lessThan: makeTestRange(-Infinity, undefined, true),
 
-  lessThanOrEqual: makeTestRange(-Infinity, undefined, undefined, true),
+  lessThanOrEqual: makeTestRange(-Infinity, undefined, true, true),
 
-  greaterThan: makeTestRange(undefined, Infinity),
+  greaterThan: makeTestRange(undefined, Infinity, false, true),
 
-  greaterThanOrEqual: makeTestRange(undefined, Infinity, true),
+  greaterThanOrEqual: makeTestRange(undefined, Infinity, true, true),
 
   // Divisible
 

--- a/src/v8n.test.js
+++ b/src/v8n.test.js
@@ -634,6 +634,8 @@ describe("rules", () => {
     expect(is.test(-4)).toBeTruthy();
     expect(is.test(3)).toBeFalsy();
     expect(is.test(4)).toBeFalsy();
+    expect(is.test(-Infinity)).toBeTruthy();
+    expect(is.test(Infinity)).toBeFalsy();
 
     const not = v8n().not.lessThan(3);
     expect(not.test(1)).toBeFalsy();
@@ -641,6 +643,32 @@ describe("rules", () => {
     expect(not.test(-4)).toBeFalsy();
     expect(not.test(3)).toBeTruthy();
     expect(not.test(4)).toBeTruthy();
+    expect(not.test(-Infinity)).toBeFalsy();
+    expect(not.test(Infinity)).toBeTruthy();
+
+    expect(
+      v8n()
+        .lessThan(-Infinity)
+        .test(-Infinity)
+    ).toBeFalsy();
+
+    expect(
+      v8n()
+        .lessThan(-Infinity)
+        .test(Infinity)
+    ).toBeFalsy();
+
+    expect(
+      v8n()
+        .lessThan(Infinity)
+        .test(-Infinity)
+    ).toBeTruthy();
+
+    expect(
+      v8n()
+        .lessThan(Number.MIN_SAFE_INTEGER)
+        .test(-Infinity)
+    ).toBeTruthy();
   });
 
   test("lessThanOrEqualTo", () => {
@@ -651,6 +679,8 @@ describe("rules", () => {
     expect(is.test(2)).toBeTruthy();
     expect(is.test(3)).toBeTruthy();
     expect(is.test(4)).toBeFalsy();
+    expect(is.test(-Infinity)).toBeTruthy();
+    expect(is.test(Infinity)).toBeFalsy();
 
     const not = v8n().not.lessThanOrEqual(3);
     expect(not.test(-4)).toBeFalsy();
@@ -659,6 +689,32 @@ describe("rules", () => {
     expect(not.test(2)).toBeFalsy();
     expect(not.test(3)).toBeFalsy();
     expect(not.test(4)).toBeTruthy();
+    expect(not.test(-Infinity)).toBeFalsy();
+    expect(not.test(Infinity)).toBeTruthy();
+
+    expect(
+      v8n()
+        .lessThanOrEqual(-Infinity)
+        .test(-Infinity)
+    ).toBeTruthy();
+
+    expect(
+      v8n()
+        .lessThanOrEqual(-Infinity)
+        .test(Infinity)
+    ).toBeFalsy();
+
+    expect(
+      v8n()
+        .lessThanOrEqual(Infinity)
+        .test(-Infinity)
+    ).toBeTruthy();
+
+    expect(
+      v8n()
+        .lessThanOrEqual(Number.MIN_SAFE_INTEGER)
+        .test(-Infinity)
+    ).toBeTruthy();
   });
 
   test("greaterThan", () => {
@@ -667,12 +723,46 @@ describe("rules", () => {
     expect(is.test(-3)).toBeFalsy();
     expect(is.test(3)).toBeFalsy();
     expect(is.test(4)).toBeTruthy();
+    expect(is.test(-Infinity)).toBeFalsy();
+    expect(is.test(Infinity)).toBeTruthy();
 
     const not = v8n().not.greaterThan(3);
     expect(not.test(2)).toBeTruthy();
     expect(not.test(-3)).toBeTruthy();
     expect(not.test(3)).toBeTruthy();
     expect(not.test(4)).toBeFalsy();
+    expect(not.test(-Infinity)).toBeTruthy();
+    expect(not.test(Infinity)).toBeFalsy();
+
+    expect(
+      v8n()
+        .greaterThan(-Infinity)
+        .test(-Infinity)
+    ).toBeFalsy();
+
+    expect(
+      v8n()
+        .greaterThan(-Infinity)
+        .test(Infinity)
+    ).toBeTruthy();
+
+    expect(
+      v8n()
+        .greaterThan(Infinity)
+        .test(-Infinity)
+    ).toBeFalsy();
+
+    expect(
+      v8n()
+        .greaterThan(Number.MIN_SAFE_INTEGER)
+        .test(-Infinity)
+    ).toBeFalsy();
+
+    expect(
+      v8n()
+        .greaterThan(Number.MAX_SAFE_INTEGER)
+        .test(Infinity)
+    ).toBeTruthy();
   });
 
   test("greaterThanOrEqual", () => {
@@ -681,12 +771,52 @@ describe("rules", () => {
     expect(is.test(-3)).toBeFalsy();
     expect(is.test(3)).toBeTruthy();
     expect(is.test(4)).toBeTruthy();
+    expect(is.test(-Infinity)).toBeFalsy();
+    expect(is.test(Infinity)).toBeTruthy();
 
     const not = v8n().not.greaterThanOrEqual(3);
     expect(not.test(2)).toBeTruthy();
     expect(not.test(-3)).toBeTruthy();
     expect(not.test(3)).toBeFalsy();
     expect(not.test(4)).toBeFalsy();
+    expect(not.test(-Infinity)).toBeTruthy();
+    expect(not.test(Infinity)).toBeFalsy();
+
+    expect(
+      v8n()
+        .greaterThanOrEqual(-Infinity)
+        .test(-Infinity)
+    ).toBeTruthy();
+
+    expect(
+      v8n()
+        .greaterThanOrEqual(-Infinity)
+        .test(Infinity)
+    ).toBeTruthy();
+
+    expect(
+      v8n()
+        .greaterThanOrEqual(Infinity)
+        .test(-Infinity)
+    ).toBeFalsy();
+
+    expect(
+      v8n()
+        .greaterThanOrEqual(Number.MIN_SAFE_INTEGER)
+        .test(-Infinity)
+    ).toBeFalsy();
+
+    expect(
+      v8n()
+        .greaterThanOrEqual(Number.MAX_SAFE_INTEGER)
+        .test(Infinity)
+    ).toBeTruthy();
+
+    expect(
+      v8n()
+        .greaterThanOrEqual(Infinity)
+        .test(Infinity)
+    ).toBeTruthy();
   });
 
   test("range", () => {


### PR DESCRIPTION
## Description

This PR fixes a bug related by #119 where `Infinity` values were being wrongly tested with _range-based_ rules.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have created my branch from a recent version of `stable`
- [X] The code is clean and easy to understand
- [X] I have added changes to the `Unreleased` section of the CHANGELOG
