### PR TITLE
Feature/instanceOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Rule `instanceOf()` to check inheritance of prototypes.
+
 ## [1.2.2] - 2018-08-29
 
 ### Fixed

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -485,7 +485,7 @@ sidebar: auto
 
 - **Usage:**
 
-  This rule verifies that the prototype of the tested value appears anywhere in the prototype chain of the provided costructor.
+  This rule verifies that the prototype of the tested value appears anywhere in the prototype chain of the provided constructor.
 
   ```js
   v8n()

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -479,6 +479,24 @@ sidebar: auto
     .test({ key: "value" }); // true
   ```
 
+### instanceOf
+
+- **Signature:** `instanceOf()`
+
+- **Usage:**
+
+  This rule verifies that the prototype of the tested value appears anywhere in the prototype chain of the provided costructor.
+
+  ```js
+  v8n()
+    .instanceOf(Date)
+    .test("hello"); // false
+
+  v8n()
+    .instanceOf(Date)
+    .test(new Date()); // true
+  ```
+
 ### lowercase
 
 - **Signature:** `lowercase()`

--- a/src/v8n.js
+++ b/src/v8n.js
@@ -92,6 +92,8 @@ const availableRules = {
 
   object: () => testType("object"),
 
+  instanceOf: instance => value => value instanceof instance,
+
   // Pattern
 
   pattern: expected => value => expected.test(value),

--- a/src/v8n.test.js
+++ b/src/v8n.test.js
@@ -464,6 +464,17 @@ describe("rules", () => {
     expect(validation.test("string")).toBeFalsy();
   });
 
+  test("object", () => {
+    const validation = v8n().object();
+    expect(validation.test([])).toBeTruthy();
+    expect(validation.test({})).toBeTruthy();
+    expect(validation.test(null)).toBeTruthy();
+    expect(validation.test(() => {})).toBeFalsy();
+    expect(validation.test(undefined)).toBeFalsy();
+    expect(validation.test("string")).toBeFalsy();
+    expect(validation.test(2)).toBeFalsy();
+  });
+
   test("number", () => {
     const noFlag = v8n().number();
     expect(noFlag.test(34)).toBeTruthy();

--- a/src/v8n.test.js
+++ b/src/v8n.test.js
@@ -475,6 +475,21 @@ describe("rules", () => {
     expect(validation.test(2)).toBeFalsy();
   });
 
+  test("instanceOf", () => {
+    const validationDate = v8n().instanceOf(Date);
+    expect(validationDate.test(new Date())).toBeTruthy();
+    expect(validationDate.test({})).toBeFalsy();
+    expect(validationDate.test(null)).toBeFalsy();
+    expect(validationDate.test("string")).toBeFalsy();
+
+    const validationObject = v8n().instanceOf(Object);
+    expect(validationObject.test(new Date())).toBeTruthy();
+    expect(validationObject.test(new Date())).toBeTruthy();
+    expect(validationObject.test({})).toBeTruthy();
+    expect(validationObject.test(null)).toBeFalsy();
+    expect(validationObject.test("string")).toBeFalsy();
+  });
+
   test("number", () => {
     const noFlag = v8n().number();
     expect(noFlag.test(34)).toBeTruthy();

--- a/src/v8n.test.js
+++ b/src/v8n.test.js
@@ -484,7 +484,6 @@ describe("rules", () => {
 
     const validationObject = v8n().instanceOf(Object);
     expect(validationObject.test(new Date())).toBeTruthy();
-    expect(validationObject.test(new Date())).toBeTruthy();
     expect(validationObject.test({})).toBeTruthy();
     expect(validationObject.test(null)).toBeFalsy();
     expect(validationObject.test("string")).toBeFalsy();


### PR DESCRIPTION
## Description

Add `instanceOf` rule.

Fixes #125

In addition i realized, that there was no test for the `object()` rule. I added some test-cases so that the tests still pass but I´m not sure if it´s intented, that f.e. `[1,3,4]` should pass the the `object()` rule. If that is not the case, I would suggest opening a new bug.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other: Add missing test for `object` validator

## Checklist:

- [x] I have created my branch from a recent version of `master`
- [x] The code is clean and easy to understand
- [x] I have made corresponding changes to the documentation
- [x] I have added changes to the `Unreleased` section of the CHANGELOG
