### PR TITLE
Add numeric rule for testing numeric strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Rule `instanceOf()` to check inheritance of prototypes.
+- Rule `numeric()` to check for strings containing numbers
 
 ## [1.2.3] - 2018-10-03
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -385,6 +385,34 @@ sidebar: auto
     .test(NaN); // false
   ```
 
+### numeric
+
+- **Signature:** `numeric()`
+
+- **Usage:**
+
+  This rule verifies that the tested value is numeric. A numeric value is any
+  string containing a finite number or a finite number. Notably `Infinity` and
+  `NaN` are not numeric.
+
+  ```js
+  v8n()
+    .numeric()
+    .test(123); // true
+
+  v8n()
+    .numeric()
+    .test("123"); // true
+
+  v8n()
+    .numeric()
+    .test("1.23"); // true
+
+  v8n()
+    .numeric()
+    .test(NaN); // false
+  ```
+
 ### boolean
 
 - **Signature:** `boolean()`

--- a/src/v8n.js
+++ b/src/v8n.js
@@ -97,6 +97,8 @@ const availableRules = {
     return isInteger(value);
   },
 
+  numeric: () => value => !isNaN(parseFloat(value)) && isFinite(value),
+
   string: () => testType("string"),
 
   boolean: () => testType("boolean"),

--- a/src/v8n.test.js
+++ b/src/v8n.test.js
@@ -578,6 +578,26 @@ describe("rules", () => {
     expect(flag.test(-Infinity)).toBeFalsy();
   });
 
+  test("numeric", () => {
+    const validation = v8n().numeric();
+    expect(validation.test("-10")).toBeTruthy();
+    expect(validation.test("0")).toBeTruthy();
+    expect(validation.test(0xff)).toBeTruthy();
+    expect(validation.test("0xFF")).toBeTruthy();
+    expect(validation.test("8e5")).toBeTruthy();
+    expect(validation.test("3.1415")).toBeTruthy();
+    expect(validation.test(+10)).toBeTruthy();
+    expect(validation.test("-0x42")).toBeFalsy();
+    expect(validation.test("7.2acdgs")).toBeFalsy();
+    expect(validation.test("")).toBeFalsy();
+    expect(validation.test({})).toBeFalsy();
+    expect(validation.test(NaN)).toBeFalsy();
+    expect(validation.test(null)).toBeFalsy();
+    expect(validation.test(true)).toBeFalsy();
+    expect(validation.test(Infinity)).toBeFalsy();
+    expect(validation.test(undefined)).toBeFalsy();
+  });
+
   test("boolean", () => {
     const validation = v8n().boolean();
     expect(validation.test(true)).toBeTruthy();


### PR DESCRIPTION
<!--- !!! PLEASE DELETE CONTENT THAT IS NOT RELEVANT !!! -->

## Description

This rule validates that a number has some sort of numeric value. The implementation is the same as jQuery's `isNumeric`. Notably `Infinity` and `NaN` are **not** numeric. The test suite is basically the same as the one in the [jQuery docs](http://api.jquery.com/jquery.isnumeric/).

<!-- A summary of the change made and how it is supposed to fix the related issue. Include relevant motivation and context. -->

Fixes #139 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have created my branch from a recent version of `master`
- [x] The code is clean and easy to understand
- [x] I have written tests to guarantee that everything is working properly
- [x] I have made corresponding changes to the documentation
- [x] I have added changes to the `Unreleased` section of the CHANGELOG