### PR TITLE
Consider trimmed empty strings valid by optional rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Rule `instanceOf()` to check inheritance of prototypes.
 - Rule `numeric()` to check for strings containing numbers
 
+### Changed
+
+- Rule `optional` now supports a flag to consider trimmed empty strings valid (`considerTrimmedEmptyString`) ([#140](https://github.com/imbrn/v8n/issues/140))
+
 ## [1.2.3] - 2018-10-03
 
 ### Fixed

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1083,16 +1083,19 @@ sidebar: auto
 
 ### optional
 
-- **Signature:** `optional(validation)`
+- **Signature:** `optional(validation, considerTrimmedEmptyString = false)`
 
 - **Arguments:**
 
   - `validation: Validation`
+  - `considerTrimmedEmptyString: boolean`
 
 - **Usage:**
 
-  Validates and optional value to pass a validation. Will return `true` for any
-  `undefined` or `null` values regardless of the given Validation.
+  Validates an optional value to pass a validation. Will return `true` for any
+  `undefined` or `null` values regardless of the given Validation. If the
+  `considerTrimmedEmptyString` argument is set to true, it will also pass if
+  the value is a trimmed empty string.
 
   ::: tip
   When the `check()` is used on this rule, an exception resulting from within
@@ -1109,6 +1112,22 @@ sidebar: auto
   validation.test(-1); // false
   validation.test(1); // true
   validation.test(null); // true
+  ```
+
+  ```js
+  const validation = v8n().optional(
+    v8n()
+      .number()
+      .positive(),
+    true // consider trimmed empty strings
+  );
+
+  validation.test(-1); // false
+  validation.test(1); // true
+  validation.test(null); // true
+  validation.test(""); // true
+  validation.test("   "); // true
+  validation.test("hello"); // false
   ```
 
 ## Built-in modifiers

--- a/src/v8n.js
+++ b/src/v8n.js
@@ -175,7 +175,9 @@ const availableRules = {
   passesAnyOf: (...validations) => value =>
     validations.some(validation => validation.test(value)),
 
-  optional: validation => value => {
+  optional: (validation, considerTrimmedEmptyString = false) => value => {
+    if (typeof value === "string" && value.trim() === "")
+      return considerTrimmedEmptyString;
     if (value !== undefined && value !== null) validation.check(value);
     return true;
   }

--- a/src/v8n.test.js
+++ b/src/v8n.test.js
@@ -1164,16 +1164,78 @@ describe("rules", () => {
     });
   });
 
-  test("optional", () => {
-    const validation = v8n().optional(
-      v8n()
-        .number()
-        .positive()
-    );
-    expect(validation.test(-1)).toBeFalsy();
-    expect(validation.test(1)).toBeTruthy();
-    expect(validation.test(null)).toBeTruthy();
-    expect(validation.test(undefined)).toBeTruthy();
+  describe("optional", () => {
+    it("should pass when validation passes", () => {
+      const optional = v8n().optional(
+        v8n()
+          .number()
+          .positive()
+      );
+
+      expect(optional.test(1)).toBe(true);
+      expect(optional.test(2)).toBe(true);
+      expect(optional.test(1000)).toBe(true);
+    });
+
+    it("should fail when validation fails", () => {
+      const optional = v8n().optional(
+        v8n()
+          .number()
+          .positive()
+      );
+
+      expect(optional.test(-1)).toBe(false);
+      expect(optional.test(-2)).toBe(false);
+      expect(optional.test(-100)).toBe(false);
+    });
+
+    it("should pass for null and undefined", () => {
+      const optional = v8n().optional(
+        v8n()
+          .number()
+          .positive()
+      );
+
+      expect(optional.test(null)).toBe(true);
+      expect(optional.test(undefined)).toBe(true);
+    });
+
+    it("should not consider trimmed empty string valid by default", () => {
+      const optional = v8n().optional(
+        v8n()
+          .number()
+          .positive()
+      );
+
+      expect(optional.test("")).toBe(false);
+      expect(optional.test("  ")).toBe(false);
+    });
+
+    it("should consider trimmed empty string valid when it is set to true", () => {
+      const optional = v8n().optional(
+        v8n()
+          .number()
+          .positive(),
+        true
+      );
+
+      expect(optional.test("")).toBe(true);
+      expect(optional.test("  ")).toBe(true);
+      expect(optional.test(-1)).toBe(false);
+      expect(optional.test("hello")).toBe(false);
+    });
+
+    it("should not consider trimmed empty string valid when it is set to false", () => {
+      const optional = v8n().optional(
+        v8n()
+          .number()
+          .positive(),
+        false
+      );
+
+      expect(optional.test("")).toBe(false);
+      expect(optional.test("  ")).toBe(false);
+    });
   });
 });
 


### PR DESCRIPTION
<!--- !!! PLEASE DELETE CONTENT THAT IS NOT RELEVANT !!! -->

## Description

Add support for considering trimmed empty strings valid by the `optional` rule, as requested by #140 

It depends on a flag (the second parameter) to be set to true. It defaults to false, so the current behavior is still working the same. But now with that flag set to `true`, trimmed empty strings will be considered valid by the `optional` rule:

```js
v8n().optional(v8n().number(), true).test("") == true
v8n().optional(v8n().number(), true).test("  ") == true
```

The current behavior still working as before:

```js
v8n().optional(v8n().number()).test("") == false
v8n().optional(v8n().number()).test("  ") == false
```


<!-- A summary of the change made and how it is supposed to fix the related issue. Include relevant motivation and context. -->

<!-- Fixes #(issue) -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please, feel free to specify what kind of change it is)

## Checklist:

- [X] I have created my branch from a recent version of `master`
- [X] The code is clean and easy to understand
- [X] I have written tests to guarantee that everything is working properly
- [X] I have made corresponding changes to the documentation
- [X] I have added changes to the `Unreleased` section of the CHANGELOG
