### PR TITLE
Fix optional rule bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Bug with `optional` rule that ignores validation when an empty string is passed ([#149](https://github.com/imbrn/v8n/issues/149))
+
 ## [1.3.0] - 2019-05-19
 
 ### Added

--- a/src/v8n.js
+++ b/src/v8n.js
@@ -176,8 +176,9 @@ const availableRules = {
     validations.some(validation => validation.test(value)),
 
   optional: (validation, considerTrimmedEmptyString = false) => value => {
-    if (typeof value === "string" && value.trim() === "")
-      return considerTrimmedEmptyString;
+    if (considerTrimmedEmptyString)
+      return typeof value === "string" && value.trim() === "";
+
     if (value !== undefined && value !== null) validation.check(value);
     return true;
   }

--- a/src/v8n.test.js
+++ b/src/v8n.test.js
@@ -1175,6 +1175,12 @@ describe("rules", () => {
       expect(optional.test(1)).toBe(true);
       expect(optional.test(2)).toBe(true);
       expect(optional.test(1000)).toBe(true);
+
+      expect(
+        v8n()
+          .optional(v8n().string())
+          .test("")
+      ).toBe(true);
     });
 
     it("should fail when validation fails", () => {


### PR DESCRIPTION
## Description

The optional rule didn't work when an empty was passed because the conditional was not considering the real `validation` when the value was an empty string, as reported by #149 

This fix inverts the conditional and checks if the `considerEmptyString` flag is enabled, so it skips to the real validation when it's false.

<!--- !!! PLEASE DELETE CONTENT THAT IS NOT RELEVANT !!! -->


<!-- A summary of the change made and how it is supposed to fix the related issue. Include relevant motivation and context. -->

<!-- Fixes #(issue) -->

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have created my branch from a recent version of `master`
- [X] The code is clean and easy to understand
- [X] I have written tests to guarantee that everything is working properly
- [x] I have added changes to the `Unreleased` section of the CHANGELOG
