### PR TITLE
fix: async rule with schema

### DIFF
--- a/src/Rule.js
+++ b/src/Rule.js
@@ -51,13 +51,17 @@ class Rule {
   }
 }
 
+function pickFn(fn, variant = "simple") {
+  return typeof fn === "object" ? fn[variant] : fn;
+}
+
 function testAux(modifiers, fn) {
   if (modifiers.length) {
     const modifier = modifiers.shift();
     const nextFn = testAux(modifiers, fn);
     return modifier.perform(nextFn);
   } else {
-    return fn;
+    return pickFn(fn);
   }
 }
 
@@ -67,7 +71,7 @@ function testAsyncAux(modifiers, fn) {
     const nextFn = testAsyncAux(modifiers, fn);
     return modifier.performAsync(nextFn);
   } else {
-    return value => Promise.resolve(fn(value));
+    return value => Promise.resolve(pickFn(fn, "async")(value));
   }
 }
 

--- a/src/v8n.test.js
+++ b/src/v8n.test.js
@@ -220,6 +220,26 @@ describe("execution functions", () => {
       });
     });
 
+    describe("working with schema's", () => {
+      it("should handle async rule within a schema", async () => {
+        v8n.extend({ asyncRule });
+
+        const validation = v8n().schema({
+          item: v8n()
+            .number()
+            .asyncRule([10, 17, 20])
+        });
+
+        await expect(
+          validation.testAsync({ item: "10" })
+        ).rejects.toBeDefined();
+        await expect(validation.testAsync({ item: 11 })).rejects.toBeDefined();
+        await expect(validation.testAsync({ item: 17 })).resolves.toEqual({
+          item: 17
+        });
+      });
+    });
+
     describe("the returned Promise", () => {
       it("should resolves when valid", async () => {
         const validation = v8n()


### PR DESCRIPTION
## Description

Async rules nested within a schema were not tested async. A `testAsync()` test would pass before an async rule was resolved. See #161 

I fixed that by applying the same pattern as modifiers with `.simple` and `.async` to schema's.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please, feel free to specify what kind of change it is)

## Checklist:

- [x] I have created my branch from a recent version of `master`
- [x] The code is clean and easy to understand
- [x] I have written tests to guarantee that everything is working properly
- [ ] I have made corresponding changes to the documentation
- [ ] I have added changes to the `Unreleased` section of the CHANGELOG
