### PR TITLE
Proxyless context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Bug with schema validation ([#166](https://github.com/imbrn/v8n/pull/166))
+- Bug with environments that cannot use the Proxy object ([#45](https://github.com/imbrn/v8n/issues/45))
 
 ## [1.3.3] - 2019-09-15
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -10,7 +10,7 @@ sidebar: auto
 
 - **Signature:** `v8n()`
 
-- **Returns:** `Proxy`
+- **Returns:** `Proxy` or `Object` in environments where `Proxy` is unavailable.
 
 - **Usage:**
 


### PR DESCRIPTION
<!--- !!! PLEASE DELETE CONTENT THAT IS NOT RELEVANT !!! -->

## Description

Added `proxylessContext` to allow v8n to work in ES5 environments without the `Proxy` object. This is mostly the work of @NoemiRozpara, but with the included bug fix from @ev-akarel (my other account), from the original PR #171 that was abandoned.

Fixes #45 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please, feel free to specify what kind of change it is)

## Checklist:

- [x] I have created my branch from a recent version of `master`
- [x] The code is clean and easy to understand
- [ ] I have written tests to guarantee that everything is working properly
   - This would require changing the way v8n tests are run, since it needs to be sandboxed in an ES5 environment. I believe this can/should be done, but perhaps not within the scope of this PR.
- [x] I have made corresponding changes to the documentation
- [x] I have added changes to the `Unreleased` section of the CHANGELOG
