### PR TITLE
Use yarn for publishing to npm using GH Action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '12', '14', '16' ]
+        node-version: [12.x, 14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
-      - run: npm ci
-      - run: npm lint
-      - run: npm test
+          node-version: ${{ matrix.node-version }}
+      - run: yarn
+      - run: yarn lint
+      - run: yarn test
 
   publish-npm:
     needs: build
@@ -31,8 +31,8 @@ jobs:
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: npm publish
+      - run: yarn
+      - run: yarn npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
@@ -41,8 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: npm ci
-      - run: npm run docs:build
+      - run: yarn
+      - run: yarn docs:build
       - name: Deploy to Github Pages 🚀
         uses: JamesIves/github-pages-deploy-action@v4.2.3
         with:


### PR DESCRIPTION
## Description

Use yarn for publishing to npm using GH Action.
This PR also changes the `node-version` matrix syntax to keep consistency with all Github Action configurations.

<!-- Fixes #(issue) -->

## Type of change

- [x] Other (please, feel free to specify what kind of change it is)

## Checklist:

- [x] I have created my branch from a recent version of `master`
- [x] The code is clean and easy to understand
