### PR TITLE
Manually deploy dispatching for GH Actions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,7 +5,8 @@ name: Node.js Package
 
 on:
   release:
-    types: [created]
+    types: [released]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
<!--- !!! PLEASE DELETE CONTENT THAT IS NOT RELEVANT !!! -->

## Description

Adds a Github Action workflow trigger that permits manually deploy dispatching (npm publish).

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

<!-- Fixes #(issue) -->

## Type of change

- [x] Other (please, feel free to specify what kind of change it is)

## Checklist:

- [x] I have created my branch from a recent version of `master`
