### PR TITLE
Bump npm package version for release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.4.0] - 2021-05-24
+## [1.4.0] - 2022-02-17
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v8n",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Dead simple fluent JavaScript validation library",
   "main": "dist/v8n.cjs.js",
   "module": "dist/v8n.esm.js",


### PR DESCRIPTION
Bumps the version in the package.json for the release. To be fair, this should have been done in a previous pull request - but the automatic release to npm was not implemented when that PR was made. This *should* be the last necessary step to publish 1.4.0.