### PR TITLE
Use correct path to vuepress dist

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,4 +48,4 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.2.3
         with:
           branch: gh-pages
-          folder: docs\.vuepress\dist
+          folder: docs/.vuepress/dist


### PR DESCRIPTION
## Description

The automatic documentation publish action was using windows path separators (`\`) which are likely not supported in the relevant GitHub action. The path to the documentation was not being found and publishing errored.  The path separators were switched for unix style forward slashes.

Fixes #221 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have created my branch from a recent version of `master`
