### PR TITLE
Fixed faulty Proxy check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Correct incorrect return type of `check` validation strategy (boolean -> void)
+- Bug with `Proxy` check where it always returned `true`
 
 ## [1.4.0] - 2022-02-17
 

--- a/src/v8n.js
+++ b/src/v8n.js
@@ -2,7 +2,7 @@ import Context from './Context';
 import optional from './rules/optional';
 
 function v8n() {
-  return typeof Proxy !== undefined
+  return typeof Proxy !== 'undefined'
     ? proxyContext(new Context())
     : proxylessContext(new Context());
 }


### PR DESCRIPTION
<!--- !!! PLEASE DELETE CONTENT THAT IS NOT RELEVANT !!! -->

## Description

The check to verify that the `Proxy` object existed in the given environment would always return `true`. Fixed the `typeof` comparison. This was totally my fault. ☹️ 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please, feel free to specify what kind of change it is)

## Checklist:

- [x] I have created my branch from a recent version of `master`
- [x] The code is clean and easy to understand
- [x] I have made corresponding changes to the documentation
- [x] I have added changes to the `Unreleased` section of the CHANGELOG
